### PR TITLE
Fix HanziToPinyin conversion of r with light tone

### DIFF
--- a/cedict.go
+++ b/cedict.go
@@ -725,7 +725,7 @@ func min(x, y, z int) int {
 	return z
 }
 
-var vowels = "AaEeiOouü"
+var vowels = "AaEeiOouür"
 
 var toneNums = "12345"
 
@@ -739,6 +739,7 @@ var mapNumToTone = map[rune][]rune{
 	'o': []rune("ōóǒòo"),
 	'u': []rune("ūúǔùu"),
 	'ü': []rune("ǖǘǚǜü"),
+	'r': []rune("rrrrr"),
 }
 
 var mapToneToNum = map[rune]string{

--- a/cedict_test.go
+++ b/cedict_test.go
@@ -316,6 +316,7 @@ func TestHanziToPinyin(t *testing.T) {
 	tests := map[string]string{
 		"":   "",
 		"  ": "",
+		"画儿": "Huà r",
 		"人民银行旁边一行人abc字母【路牌】，平行宇宙发行股票。": "Rén mín yín háng páng biān yī xíng rén abc zì mǔ [lù pái], píng xíng yǔ zhòu fā xíng gǔ piào.",
 		"我的大王！": "Wǒ de dà wáng!",
 		//"你好。我饿了。":       "Nǐ hǎo. Wǒ èle.",


### PR DESCRIPTION
Thanks for you great work.

I noticed that HanziToPinyin does not properly take light tone `r` character into consideration, resulting in "r5" after conversion
An example is 画儿, which is converted to `Huà r5`

I fixed this problem so that `r5` is properly converted to just `r`.
I set all 5 characters of corresponding `mapNumToTone` value to `r`, where the first 4 characters can be anything (If my understanding is correct `r` can only come with light tone, so it does not matter what the first 4 characters are.)