### PR TITLE
Fix guessToneIndex causing panic when handling multi byte char in the middle

### DIFF
--- a/cedict.go
+++ b/cedict.go
@@ -666,9 +666,10 @@ func FixSymbolSpaces(s string) string {
 // vowel in the string, as a guess for which gets the tone.
 func guessToneIndex(s string) int {
 	for _, r := range vowels {
-		i := strings.IndexRune(s, r)
-		if i >= 0 {
-			return i
+		byteIndex := strings.IndexRune(s, r)
+		if byteIndex >= 0 {
+			runeIndex := len([]rune(s[0:byteIndex]))
+			return runeIndex
 		}
 	}
 	return -1

--- a/cedict_test.go
+++ b/cedict_test.go
@@ -317,6 +317,7 @@ func TestHanziToPinyin(t *testing.T) {
 		"":   "",
 		"  ": "",
 		"画儿": "Huà r",
+		"省略": "Shěng lüè",
 		"人民银行旁边一行人abc字母【路牌】，平行宇宙发行股票。": "Rén mín yín háng páng biān yī xíng rén abc zì mǔ [lù pái], píng xíng yǔ zhòu fā xíng gǔ piào.",
 		"我的大王！": "Wǒ de dà wáng!",
 		//"你好。我饿了。":       "Nǐ hǎo. Wǒ èle.",


### PR DESCRIPTION
Fixed a bug where `guessToneIndex` was returning byte index instead of rune index.
As an example it was guessing the index was 3 for `略 (lüè)`, which is out of range in terms of rune array, so it was causing panic. 
The correct index is 2.