### PR TITLE
Support returning all hanzi entry matches and fix tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
-# `cedict` 漢英詞典Go軟件包
+# `cedict` 漢英詞典 Go 軟件包
 
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg?style=flat-square)](https://godoc.org/github.com/jcramb/cedict)
-[![Go Report Card](https://goreportcard.com/badge/github.com/jcramb/cedict?style=flat-square)](https://goreportcard.com/report/github.com/jcramb/cedict)
-[![Build Status](https://img.shields.io/travis/jcramb/cedict/master?style=flat-square)](https://travis-ci.org/jcramb/cedict)
-[![Coveralls](https://img.shields.io/coveralls/github/jcramb/cedict/master?style=flat-square)](https://coveralls.io/github/jcramb/cedict)
-[![License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](LICENSE) 
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg?style=flat-square)](https://godoc.org/github.com/Destaq/cedict)
+[![Go Report Card](https://goreportcard.com/badge/github.com/Destaq/cedict?style=flat-square)](https://goreportcard.com/report/github.com/Destaq/cedict)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](LICENSE)
 
-# Overview 
+# Overview
 
-Golang library for the community maintained Chinese-English dictionary (CC-CEDICT), published by MDBG. 
+Golang library for the community maintained Chinese-English dictionary (CC-CEDICT), published by MDBG.
 
 > [https://www.mdbg.net/chinese/dictionary?page=cedict](https://www.mdbg.net/chinese/dictionary?page=cedict)
 
@@ -17,16 +15,16 @@ The basic format of a CEDICT entry is:
     Traditional Simplified [pin1 yin1] /American English equivalent 1/equivalent 2/
     漢字 汉字 [han4 zi4] /Chinese character/CL:個|个/
 
-
 # Install
+
 First grab the latest version of the package,
 
-    go get -u github.com/jcramb/cedict
+    go get -u github.com/Destaq/cedict
 
 Next, include it in your application:
 
 ```go
-import "github.com/jcramb/cedict"
+import "github.com/Destaq/cedict"
 ```
 
 # Getting Started
@@ -50,5 +48,4 @@ fmt.Printf("%s\n", cedict.PinyinTones(d.HanziToPinyin("你好，世界！")))
 
 Copyright 2020 John Cramb. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/jcramb/cedict/blob/master/LICENSE) in the project root for license information.
-
+Licensed under the MIT License. See [LICENSE](https://github.com/Destaq/cedict/blob/master/LICENSE) in the project root for license information.

--- a/cedict.go
+++ b/cedict.go
@@ -314,6 +314,20 @@ func (d *Dict) GetByHanzi(s string) *Entry {
 	return nil
 }
 
+// GetAllByHanzi returns all the Dict entries that match the hanzi.
+// Supports input using traditional or simplified characters.
+func (d *Dict) GetAllByHanzi(s string) []*Entry {
+	d.lazyLoad()
+	s = strings.TrimSpace(s)
+	var results []*Entry
+	for _, e := range d.e {
+		if e.Traditional == s || e.Simplified == s {
+			results = append(results, e)
+		}
+	}
+	return results
+}
+
 // GetByPinyin returns hanzi matching the given pinyin string.
 // Supports pinyin in plaintext or with tones/tone numbers.
 // With plaintext, all tone variations are considered matching.

--- a/cedict_test.go
+++ b/cedict_test.go
@@ -72,6 +72,17 @@ func TestHanzi(t *testing.T) {
 	}
 }
 
+func TestAllHanzi(t *testing.T) {
+	d := New()
+	elements := d.GetAllByHanzi("听")
+	if len(elements) != 2 {
+		t.Fail()
+	}
+	for _, e := range elements {
+		t.Logf("AllHanzi:  %s\n", e.Marshal())
+	}
+}
+
 func TestPinyin(t *testing.T) {
 	d := New()
 
@@ -379,8 +390,8 @@ func ExampleDict_hanziToPinyin() {
 	fmt.Printf("%s (tones)     '%s'\n", hans, FixSymbolSpaces(PinyinTones(d.HanziToPinyin(hans))))
 	// Output:
 	// 你喜歡學中文嗎？ (plaintext) 'Ni xi huan xue zhong wen ma ?'
-	// 你喜歡學中文嗎？ (tonenums)  'Ni3 xi3 huan5 xue2 zhong1 wen2 ma3 ?'
-	// 你喜歡學中文嗎？ (tones)     'Nǐ xǐ huan xué zhōng wén mǎ?'
+	// 你喜歡學中文嗎？ (tonenums)  'Ni3 xi3 huan5 xue2 zhong1 wen2 ma2 ?'
+	// 你喜歡學中文嗎？ (tones)     'Nǐ xǐ huan xué zhōng wén má?'
 }
 
 func BenchmarkHanziToPinyin(b *testing.B) {

--- a/cmd/cedict/main.go
+++ b/cmd/cedict/main.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/jcramb/cedict"
+	"github.com/Destaq/cedict"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jcramb/cedict
+module github.com/Destaq/cedict
 
 go 1.13
 


### PR DESCRIPTION
Thanks for the great library! I have two small proposed changes.

1. Fixed a failing test (probably due to a newer version of CEDICT coming out)
2. Added a new method called `GetAllByHanzi`, which returns all of the entries that match a given hanzi phrase. Currently, there is no way of doing this, and it means that some hanzi with multiple entries don't have all of them returned (e.g. 听）.